### PR TITLE
Fixes ESC-to-close functionality.

### DIFF
--- a/assets/css/stylesheets/tooltips.scss
+++ b/assets/css/stylesheets/tooltips.scss
@@ -268,7 +268,7 @@ $tip--no-delay: .18s !default;
 
 
 // hide tool tips if the ESC key is hit
-.#{$ns}a11y-tip--hide .#{$ns}a11y-tip__help {
+.#{$ns}a11y-tip--hide {
 	display: none;
 }
 

--- a/assets/css/tooltips.css
+++ b/assets/css/tooltips.css
@@ -142,7 +142,7 @@
         top: 50%;
         transform: translate(10px, -50%); } }
 
-.a11y-tip--hide .a11y-tip__help {
+.a11y-tip--hide {
   display: none; }
 
 .no-js .a11y-tip__help:not([role]) {

--- a/assets/js/tooltips.js
+++ b/assets/js/tooltips.js
@@ -155,10 +155,8 @@
 
 		  	// hide the tooltip on blur of the trigger
 			trigger.addEventListener( "blur", function( e ) {
-				var parent = this.parentNode;
-
-				if( a11yTT.hasClass( parent, 'a11y-tip--hide') ) {
-			  		a11yTT.removeClass( parent, 'a11y-tip--hide');
+				if( a11yTT.hasClass( this.nextElementSibling, 'a11y-tip--hide') ) {
+			  		a11yTT.removeClass( this.nextElementSibling, 'a11y-tip--hide');
 				}
 			}, false );
 
@@ -173,7 +171,7 @@
 
 				if ( e.which == 27 ) {
 					e.preventDefault();
-					a11yTT.addClass( this, 'a11y-tip--hide' )
+					a11yTT.addClass( this.nextElementSibling, 'a11y-tip--hide' )
 					return false;
 				}
 


### PR DESCRIPTION
First, thanks for porting this to ES5, much appreciated.

While working with the [demo](https://timwright12.github.io/a11y-tooltips/) I noticed the ESC-to-close functionality wasn't working.

Seems like the trigger element is the one getting .a11y-tip--hide applied (can be seen in the demo): https://github.com/timwright12/a11y-tooltips/blob/master/assets/js/tooltips.js#L176

Needed to simplify the selector as well, so it's not looking for a child of the trigger: https://github.com/timwright12/a11y-tooltips/blob/master/assets/css/stylesheets/tooltips.scss#L270 